### PR TITLE
v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## vNext
+
+Fixed:
+
+- Refactorings for more Clean Code
+
 ## v2.0.4 (2025-04-16)
 
 Add:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Add:
 
 Fixed:
 
+- Update `BasicTextPreprocessor` to support Emoji characters too
 - Refactorings for more Clean Code
 
 Breaking Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Add:
 
 Fixed:
 
+- Fixed text tokenization to correctly remove special characters
 - Update `BasicTextPreprocessor` to support Emoji characters too
 - Refactorings for more Clean Code
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## vNext
 
+Add:
+
+- Added `VectorTextResultItem.Id` property so it's easy to get the database ID for search results if necessary.
+
 Fixed:
 
 - Refactorings for more Clean Code
+
+Breaking Changes:
+
+- The `.Search` and `.SearchAsync` methods now return a `IVectorTextResultItem<TId, TDocument, TMetadata>` instead of `VectorTextResultItem<TDocument, TMetadata>`. If you're using things like the documentation shows, then you wont see any changes or have any issues with this update.
 
 ## v2.0.4 (2025-04-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## vNext
+## v2.1.0
 
 Add:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Add:
 
 - Added `VectorTextResultItem.Id` property so it's easy to get the database ID for search results if necessary.
+- `IVectorDatabase` now inherits from `IEnumerable` so you can easily look through the texts documents that have been added to the database.
 
 Fixed:
 

--- a/docs/docs/get-started/data-management/index.md
+++ b/docs/docs/get-started/data-management/index.md
@@ -6,7 +6,7 @@ title: Data Management
 
 Since `Build5Nines.SharpVector` is a database, it also has data management methods available. These methods enable you to add, remove, and update the text documents that are vectorized and indexed within the semantic database.
 
-## Get Text ID
+## Get Text Item IDs
 
 Every text item within a `Build5Nines.SharpVector` database is assigned a unique identifier (ID). There are a few ways to get access to the ID of the text items.
 
@@ -22,10 +22,86 @@ Every text item within a `Build5Nines.SharpVector` database is assigned a unique
 
 === ".Search()"
 
-    
+    When you perform a semantic search, the search results will contain the list of texts; each have an ID property.
 
-## Update Text and Metadata
+    ```csharp
+    var results = vdb.Search("query text");
+
+    foreach(var text in results.Texts) {
+        var id = text.Id;
+        var text = text.Text;
+        var metadata = text.Metadata;
+        // do something here    
+    }
+    ```
+
+=== "Enumerator"
+
+    The `IVectorDatabase` classes implement `IEnumerable` so you can easily loop through all the text items that have been added to the database.
+
+    ```csharp
+    foreach(var item in vdb) {
+        var id = item.Id;
+        var text = item.Text;
+        var metadata = item.Metadata;
+        var vector = item.Vector;
+
+        // do something here
+    }
+    ```
+
+## Get
+
+If you know the `id` of a Text item in the database, you can retrieve it directly.
+
+### Get By Id
+
+The `.GetText` method can be used to retrieve a text item from the vector database directly.
+
+```csharp
+vdb.GetText(id);
+```
+
+## Update
+
+Once text items have been added to the database "Update" methods can be used to modify them.
+
+### Update Text
+
+The `.UpdateText` method can be used to update the `Text` value, and associated vectors will be updated.
+
+```csharp
+vdb.UpdateText(id, newTxt);
+```
+
+When the `Text` is updated, new vector embeddings are generated for the new text.
+
+### Update Metadata
+
+The `.UpdateTextMetadata` method can be used to update the `Metadata` for a given text item by `Id`.
+
+```csharp
+vdb.UpdateTextMetadata(id, newTxt);
+```
+
+When `Metadata` is updated, the vector embeddings are not updated.
+
+### Update Text and Metadata
+
+The `.UpdateTextAndMetadata` method can be used to update the `Text` and `Metadata` for a text item in the database for the given text item `Id`.
 
 ```csharp
 vdb.UpdateTextAndMetadata(id, newTxt, newMetadata);
+```
+
+## Delete
+
+The vector database supports the ability to delete text items.
+
+### Delete Text
+
+The `.DeleteText` method can be used to delete a text item form the database for the given `Id'.
+
+```csharp
+vdb.DeleteText(id);
 ```

--- a/docs/docs/get-started/data-management/index.md
+++ b/docs/docs/get-started/data-management/index.md
@@ -1,0 +1,31 @@
+---
+title: Data Management
+
+---
+# Data Management
+
+Since `Build5Nines.SharpVector` is a database, it also has data management methods available. These methods enable you to add, remove, and update the text documents that are vectorized and indexed within the semantic database.
+
+## Get Text ID
+
+Every text item within a `Build5Nines.SharpVector` database is assigned a unique identifier (ID). There are a few ways to get access to the ID of the text items.
+
+=== ".AddText()"
+
+    When adding an individual text item to the vector database, the ID value will be returned:
+
+    ```csharp
+    var id = vdb.AddText(txt, metadata);
+
+    var id = await vdb.AddTextAsync(txt, metadata);
+    ```
+
+=== ".Search()"
+
+    
+
+## Update Text and Metadata
+
+```csharp
+vdb.UpdateTextAndMetadata(id, newTxt, newMetadata);
+```

--- a/docs/docs/get-started/data-management/index.md
+++ b/docs/docs/get-started/data-management/index.md
@@ -6,7 +6,7 @@ title: Data Management
 
 Since `Build5Nines.SharpVector` is a database, it also has data management methods available. These methods enable you to add, remove, and update the text documents that are vectorized and indexed within the semantic database.
 
-## Get Text Item IDs
+## Get Text Item ID
 
 Every text item within a `Build5Nines.SharpVector` database is assigned a unique identifier (ID). There are a few ways to get access to the ID of the text items.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -137,6 +137,10 @@ nav:
       - Prerequisites: get-started/#prerequisites
       - Install Nuget Package: get-started/#install-nuget-package
       - Basic Example: get-started/#basic-example
+      - Data Management:
+          - get-started/data-management/index.md
+          - Get Text ID: get-started/data-management/#get-text-id
+          - Update Text and Metadata: get-started/data-management/#update-text-and-metadata
   - Concepts:
       - concepts/index.md
       - What is a Vector Database?: concepts/#what-is-a-vector-database

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -139,10 +139,10 @@ nav:
       - Basic Example: get-started/#basic-example
       - Data Management:
           - get-started/data-management/index.md
-          - Get Text Item IDs: get-started/data-management/#get-text-item-ids
-          - Get By Id: get-started/data-management/#get-by-id
-          - Update: get-started/data-management/#update
-          - Delete: get-started/data-management/#delete
+          - Get Text Item Id: get-started/data-management/#get-text-item-id
+          - Get Item By Id: get-started/data-management/#get
+          - Update Item: get-started/data-management/#update
+          - Delete Item: get-started/data-management/#delete
   - Concepts:
       - concepts/index.md
       - What is a Vector Database?: concepts/#what-is-a-vector-database

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -139,8 +139,10 @@ nav:
       - Basic Example: get-started/#basic-example
       - Data Management:
           - get-started/data-management/index.md
-          - Get Text ID: get-started/data-management/#get-text-id
-          - Update Text and Metadata: get-started/data-management/#update-text-and-metadata
+          - Get Text Item IDs: get-started/data-management/#get-text-item-ids
+          - Get By Id: get-started/data-management/#get-by-id
+          - Update: get-started/data-management/#update
+          - Delete: get-started/data-management/#delete
   - Concepts:
       - concepts/index.md
       - What is a Vector Database?: concepts/#what-is-a-vector-database

--- a/src/Build5Nines.SharpVector/Build5Nines.SharpVector.csproj
+++ b/src/Build5Nines.SharpVector/Build5Nines.SharpVector.csproj
@@ -9,7 +9,7 @@
     <PackageId>Build5Nines.SharpVector</PackageId>
     <PackageProjectUrl>https://sharpvector.build5nines.com</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Build5Nines/SharpVector</RepositoryUrl>
-    <Version>2.0.4</Version>
+    <Version>2.1.0</Version>
     <Description>Lightweight In-memory Vector Database to embed in any .NET Applications</Description>
     <Copyright>Copyright (c) 2025 Build5Nines LLC</Copyright>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Build5Nines.SharpVector/IVectorDatabase.cs
+++ b/src/Build5Nines.SharpVector/IVectorDatabase.cs
@@ -80,7 +80,7 @@ public interface IVectorDatabase<TId, TMetadata, TDocument>
     /// <param name="pageIndex">The page index of the search results. Default is 0.</param>
     /// <param name="pageCount">The number of search results per page. Default is Null and returns all results.</param>
     /// <returns></returns>
-    IVectorTextResult<TDocument, TMetadata> Search(TDocument queryText, float? threshold = null, int pageIndex = 0, int? pageCount = null);
+    IVectorTextResult<TId, TDocument, TMetadata> Search(TDocument queryText, float? threshold = null, int pageIndex = 0, int? pageCount = null);
 
     /// <summary>
     /// Performs an asynchronous search vector search to find the top N most similar texts to the given text
@@ -90,7 +90,7 @@ public interface IVectorDatabase<TId, TMetadata, TDocument>
     /// <param name="pageIndex">The page index of the search results. Default is 0.</param>
     /// <param name="pageCount">The number of search results per page. Default is Null and returns all results.</param>
     /// <returns></returns>
-    Task<IVectorTextResult<TDocument, TMetadata>> SearchAsync(TDocument queryText, float? threshold = null, int pageIndex = 0, int? pageCount = null);
+    Task<IVectorTextResult<TId, TDocument, TMetadata>> SearchAsync(TDocument queryText, float? threshold = null, int pageIndex = 0, int? pageCount = null);
 
 
     [Obsolete("Use SerializeToBinaryStreamAsync Instead")]

--- a/src/Build5Nines.SharpVector/IVectorDatabase.cs
+++ b/src/Build5Nines.SharpVector/IVectorDatabase.cs
@@ -9,6 +9,7 @@ namespace Build5Nines.SharpVector;
 /// <typeparam name="TMetadata"></typeparam>
 /// <typeparam name="TDocument"></typeparam>
 public interface IVectorDatabase<TId, TMetadata, TDocument>
+    : IEnumerable<IVectorTextDatabaseItem<TId, TDocument, TMetadata>>
     where TId : notnull
 {
     /// <summary>

--- a/src/Build5Nines.SharpVector/MemoryVectorDatabaseBase.cs
+++ b/src/Build5Nines.SharpVector/MemoryVectorDatabaseBase.cs
@@ -9,14 +9,9 @@ using System.IO.Compression;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Build5Nines.SharpVector.Embeddings;
-using System.Runtime.InteropServices;
 
 namespace Build5Nines.SharpVector;
 
-public abstract class MemoryVectorDatabaseBase
-{
-
-}
 
 public abstract class MemoryVectorDatabaseBase<TId, TMetadata, TVectorStore, TVocabularyStore, TVocabularyKey, TVocabularyValue, TIdGenerator, TTextPreprocessor, TVectorizer, TVectorComparer>
     : IVectorDatabase<TId, TMetadata, TVocabularyKey>

--- a/src/Build5Nines.SharpVector/MemoryVectorDatabaseBase.cs
+++ b/src/Build5Nines.SharpVector/MemoryVectorDatabaseBase.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Build5Nines.SharpVector.Embeddings;
 using System.Runtime.ExceptionServices;
+using System.Collections;
 
 namespace Build5Nines.SharpVector;
 
@@ -145,8 +146,14 @@ public abstract class MemoryVectorDatabaseBase<TId, TMetadata, TVectorStore, TVo
         if (VectorStore.ContainsKey(id))
         {
             var existing = VectorStore.Get(id);
-            existing.Metadata = metadata;
-            VectorStore.Set(id, existing);
+
+            var item = new VectorTextItem<TVocabularyKey, TMetadata>(
+                existing.Text,
+                metadata,
+                existing.Vector
+            );
+            
+            VectorStore.Set(id, item);
         }
         else
         {
@@ -340,6 +347,16 @@ public abstract class MemoryVectorDatabaseBase<TId, TMetadata, TVectorStore, TVo
         }
         DeserializeFromBinaryStreamAsync(stream).Wait();
     }
+
+    public IEnumerator<IVectorTextDatabaseItem<TId, TVocabularyKey, TMetadata>> GetEnumerator()
+    {
+        return VectorStore.Select(kvp => new VectorTextDatabaseItem<TId, TVocabularyKey, TMetadata>(kvp.Key, kvp.Value.Text, kvp.Value.Metadata, kvp.Value.Vector)).GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
 }
 
 
@@ -472,8 +489,14 @@ public abstract class MemoryVectorDatabaseBase<TId, TMetadata, TVectorStore, TId
         if (VectorStore.ContainsKey(id))
         {
             var existing = VectorStore.Get(id);
-            existing.Metadata = metadata;
-            VectorStore.Set(id, existing);
+
+            var item = new VectorTextItem<string, TMetadata>(
+                existing.Text,
+                metadata,
+                existing.Vector
+            );
+            
+            VectorStore.Set(id, item);
         }
         else
         {
@@ -660,4 +683,13 @@ public abstract class MemoryVectorDatabaseBase<TId, TMetadata, TVectorStore, TId
         DeserializeFromBinaryStreamAsync(stream).Wait();
     }
 
+    public IEnumerator<IVectorTextDatabaseItem<TId, string, TMetadata>> GetEnumerator()
+    {
+        return VectorStore.Select(kvp => new VectorTextDatabaseItem<TId, string, TMetadata>(kvp.Key, kvp.Value.Text, kvp.Value.Metadata, kvp.Value.Vector)).GetEnumerator();
+    }
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
 }

--- a/src/Build5Nines.SharpVector/Preprocessing/BasicTextPreprocessor.cs
+++ b/src/Build5Nines.SharpVector/Preprocessing/BasicTextPreprocessor.cs
@@ -1,72 +1,92 @@
 namespace Build5Nines.SharpVector.Preprocessing;
 
+using System.Globalization;
+using System.Security.AccessControl;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Text.RegularExpressions;
 
 public class BasicTextPreprocessor : ITextPreprocessor<string>
 {
-    // private const string space = " ";
-    // private const char charSpace = ' ';
+    private const string space = " ";
+    private const char charSpace = ' ';
 
-    // private const string regexMatchChineseCharacters = @"\p{IsCJKUnifiedIdeographs}";
-    private const string regexRemovePunctuation = @"[^\p{IsCJKUnifiedIdeographs}\w\s\d\p{So}\p{Sk}]";
-    // private const string regexTokenize = @"[\p{IsCJKUnifiedIdeographs}]|[a-z0-9]+";
-    // private const string regexWhitespace = @"\s+";
-    // private const string regexNotAWord = @"[^\w\s]";
+    private const string regexChineseCharactersPattern = @"\p{IsCJKUnifiedIdeographs}";
+    private const string regexRemovePunctuation = @"[\p{P}$^`~=+|<>]"; // @"[\p{P}]";
+    private const string regexTokenize = @"[\p{IsCJKUnifiedIdeographs}]|\p{So}\p{Sk}|[a-z0-9]+";
+    private const string regexWhitespacePattern = @"\s+";
+    private const string regexEmojiPattern = @"[\p{So}\uD83C-\uDBFF\uDC00-\uDFFF]";    
 
     public IEnumerable<string> TokenizeAndPreprocess(string text)
     {
-        // text = text.ToLower();
-
-        // // Check if text contains Chinese characters using the CJK Unified Ideographs block
-        // if (Regex.IsMatch(text, regexMatchChineseCharacters))
-        // {
-        //     // Remove punctuation (excluding Chinese characters)
-        //     text = Regex.Replace(text, regexRemovePunctuation, string.Empty);
-        //     // Tokenize either by matching individual Chinese characters or contiguous word tokens (for Latin letters/digits)
-        //     var tokens = Regex.Matches(text, regexTokenize)
-        //                       .Cast<Match>()
-        //                       .Select(m => m.Value);
-        //     return tokens;
-        // }
-        // else
-        // {
-        //     text = Regex.Replace(text, regexNotAWord, string.Empty);
-        //     text = Regex.Replace(text, regexWhitespace, space).Trim();
-        //     return text.Split(charSpace);
-        // }
-
         if (string.IsNullOrWhiteSpace(text)) return Array.Empty<string>();
 
         text = text.ToLower();
+
+        // Remove punctuation (excluding Chinese characters)
         text = Regex.Replace(text, regexRemovePunctuation, string.Empty);
+        //text = Regex.Replace(text, @"[$^`~=+|<>]", space);
 
-        string pattern = 
-            @"(\p{IsCJKUnifiedIdeographs})" +  // Match individual Chinese characters
-            @"|([\p{L}\p{M}\d]+)" +            // Match words (letters, numbers, including accents/diacritics)
-            @"|([\p{So}\p{Sk}])";              // Match emoji and symbols
+        Console.WriteLine($"Text after removing punctuation: {text}");
 
-        MatchCollection matches = Regex.Matches(text, pattern);
-        List<string> result = new List<string>();
-
-        foreach (Match match in matches)
+        // Check if text contains Chinese characters using the CJK Unified Ideographs block
+        if (Regex.IsMatch(text, regexChineseCharactersPattern))
         {
-            // Split blocks of Chinese characters into individual characters
-            if (Regex.IsMatch(match.Value, @"^\p{IsCJKUnifiedIdeographs}+$"))
+            if (Regex.IsMatch(text, regexEmojiPattern))
             {
-                result.AddRange(match.Value.ToCharArray().Select(c => c.ToString()));
-            }
-            else
-            {
-                result.Add(match.Value);
+                // Has Emoji
+                text = SpacePadSpecialCharacters(text, new string[] { regexEmojiPattern, regexChineseCharactersPattern });
+                // remove extra whitespace characters
+                text = Regex.Replace(text, regexWhitespacePattern, space).Trim();
+            } else {
+                // No Emoji
+                // Tokenize either by matching individual Chinese characters or contiguous word tokens (for Latin letters/digits)
+                var tokens = Regex.Matches(text, regexTokenize)
+                                .Cast<Match>()
+                                .Select(m => m.Value);
+                return tokens;
             }
         }
+        else
+        {
+            // if text contains emojis
+            if (Regex.IsMatch(text, regexEmojiPattern))
+            {
+                text = SpacePadSpecialCharacters(text, new string[] { regexEmojiPattern });
+            }
+            
+            // remove extra whitespace characters
+            text = Regex.Replace(text, regexWhitespacePattern, space).Trim();   
+        }
 
-        return result.ToArray();
+        return text.Split(charSpace);
     }
 
     public async Task<IEnumerable<string>> TokenizeAndPreprocessAsync(string text)
     {
         return await Task.Run(() => TokenizeAndPreprocess(text));
+    }
+
+
+    private static string SpacePadSpecialCharacters(string text, string[] regexPatterns){
+        var enumerator = StringInfo.GetTextElementEnumerator(text);
+        StringBuilder sb = new StringBuilder();
+        int i;
+        while(enumerator.MoveNext())
+        {
+            var element = enumerator.GetTextElement();
+
+            for (i = 0; i < regexPatterns.Length; i++)
+            {
+                if (Regex.IsMatch(element, regexPatterns[i]))
+                {
+                    element = space + element + space;
+                    break;
+                }
+            }
+
+            sb.Append(element);
+        }
+        return sb.ToString();
     }
 }

--- a/src/Build5Nines.SharpVector/Preprocessing/BasicTextPreprocessor.cs
+++ b/src/Build5Nines.SharpVector/Preprocessing/BasicTextPreprocessor.cs
@@ -1,8 +1,6 @@
 namespace Build5Nines.SharpVector.Preprocessing;
 
 using System.Globalization;
-using System.Security.AccessControl;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -13,7 +11,7 @@ public class BasicTextPreprocessor : ITextPreprocessor<string>
 
     private const string regexChineseCharactersPattern = @"\p{IsCJKUnifiedIdeographs}";
     private const string regexRemovePunctuation = @"[\p{P}$^`~=+|<>]"; // @"[\p{P}]";
-    private const string regexTokenize = @"[\p{IsCJKUnifiedIdeographs}]|\p{So}\p{Sk}|[a-z0-9]+";
+    // private const string regexTokenize = @"[\p{IsCJKUnifiedIdeographs}]|\p{So}\p{Sk}|[a-z0-9]+";
     private const string regexWhitespacePattern = @"\s+";
     private const string regexEmojiPattern = @"[\p{So}\uD83C-\uDBFF\uDC00-\uDFFF]";    
 
@@ -21,45 +19,53 @@ public class BasicTextPreprocessor : ITextPreprocessor<string>
     {
         if (string.IsNullOrWhiteSpace(text)) return Array.Empty<string>();
 
+        // Tokens should always be lower case
         text = text.ToLower();
 
         // Remove punctuation (excluding Chinese characters)
         text = Regex.Replace(text, regexRemovePunctuation, string.Empty);
-        //text = Regex.Replace(text, @"[$^`~=+|<>]", space);
 
-        Console.WriteLine($"Text after removing punctuation: {text}");
+        // Space pad special characters (Emoji and Chinese characters)
+        text = SpacePadSpecialCharacters(text);
 
-        // Check if text contains Chinese characters using the CJK Unified Ideographs block
-        if (Regex.IsMatch(text, regexChineseCharactersPattern))
-        {
-            if (Regex.IsMatch(text, regexEmojiPattern))
-            {
-                // Has Emoji
-                text = SpacePadSpecialCharacters(text, new string[] { regexEmojiPattern, regexChineseCharactersPattern });
-                // remove extra whitespace characters
-                text = Regex.Replace(text, regexWhitespacePattern, space).Trim();
-            } else {
-                // No Emoji
-                // Tokenize either by matching individual Chinese characters or contiguous word tokens (for Latin letters/digits)
-                var tokens = Regex.Matches(text, regexTokenize)
-                                .Cast<Match>()
-                                .Select(m => m.Value);
-                return tokens;
-            }
-        }
-        else
-        {
-            // if text contains emojis
-            if (Regex.IsMatch(text, regexEmojiPattern))
-            {
-                text = SpacePadSpecialCharacters(text, new string[] { regexEmojiPattern });
-            }
-            
-            // remove extra whitespace characters
-            text = Regex.Replace(text, regexWhitespacePattern, space).Trim();   
-        }
+        // Remove extra whitespace characters
+        text = Regex.Replace(text, regexWhitespacePattern, space).Trim();   
 
+        // Split to Token array
         return text.Split(charSpace);
+
+
+        // // Check if text contains Chinese characters using the CJK Unified Ideographs block
+        // if (Regex.IsMatch(text, regexChineseCharactersPattern))
+        // {
+        //     if (Regex.IsMatch(text, regexEmojiPattern))
+        //     {
+        //         // Has Emoji
+        //         text = SpacePadSpecialCharacters(text, new string[] { regexEmojiPattern, regexChineseCharactersPattern });
+        //         // remove extra whitespace characters
+        //         text = Regex.Replace(text, regexWhitespacePattern, space).Trim();
+        //     } else {
+        //         // No Emoji
+        //         // Tokenize either by matching individual Chinese characters or contiguous word tokens (for Latin letters/digits)
+        //         var tokens = Regex.Matches(text, regexTokenize)
+        //                         .Cast<Match>()
+        //                         .Select(m => m.Value);
+        //         return tokens;
+        //     }
+        // }
+        // else
+        // {
+        //     // if text contains emojis
+        //     if (Regex.IsMatch(text, regexEmojiPattern))
+        //     {
+        //         text = SpacePadSpecialCharacters(text, new string[] { regexEmojiPattern });
+        //     }
+            
+        //     // remove extra whitespace characters
+        //     text = Regex.Replace(text, regexWhitespacePattern, space).Trim();   
+        // }
+
+        // return text.Split(charSpace);
     }
 
     public async Task<IEnumerable<string>> TokenizeAndPreprocessAsync(string text)
@@ -68,7 +74,35 @@ public class BasicTextPreprocessor : ITextPreprocessor<string>
     }
 
 
-    private static string SpacePadSpecialCharacters(string text, string[] regexPatterns){
+    private static string SpacePadSpecialCharacters(string text)
+    {
+        var spacePadPatterns = new List<string>();
+
+        // Contains Chinese characters?
+        if (Regex.IsMatch(text, regexChineseCharactersPattern))
+        {
+            // Space pad Chinese characters
+            spacePadPatterns.Add(regexChineseCharactersPattern);
+        }
+
+        // Contains Emoji?
+        if (Regex.IsMatch(text, regexEmojiPattern))
+        {
+            // Space pad Emoji characters
+            spacePadPatterns.Add(regexEmojiPattern);
+        }
+
+        if (spacePadPatterns.Count > 0)
+        {
+            // Space pad special characters based on the patterns selected
+            text = SpacePadSpecialCharacters(text, spacePadPatterns.ToArray());
+        }
+
+        return text;
+    }
+
+    private static string SpacePadSpecialCharacters(string text, string[] regexPatterns)
+    {
         var enumerator = StringInfo.GetTextElementEnumerator(text);
         StringBuilder sb = new StringBuilder();
         int i;

--- a/src/Build5Nines.SharpVector/Preprocessing/BasicTextPreprocessor.cs
+++ b/src/Build5Nines.SharpVector/Preprocessing/BasicTextPreprocessor.cs
@@ -5,36 +5,64 @@ using System.Text.RegularExpressions;
 
 public class BasicTextPreprocessor : ITextPreprocessor<string>
 {
-    private const string space = " ";
-    private const char charSpace = ' ';
+    // private const string space = " ";
+    // private const char charSpace = ' ';
 
-    private const string regexMatchChineseCharacters = @"\p{IsCJKUnifiedIdeographs}";
-    private const string regexRemovePunctuation = @"[^\p{IsCJKUnifiedIdeographs}\w\s]";
-    private const string regexTokenize = @"[\p{IsCJKUnifiedIdeographs}]|[a-z0-9]+";
-    private const string regexWhitespace = @"\s+";
-    private const string regexNotAWord = @"[^\w\s]";
+    // private const string regexMatchChineseCharacters = @"\p{IsCJKUnifiedIdeographs}";
+    private const string regexRemovePunctuation = @"[^\p{IsCJKUnifiedIdeographs}\w\s\d\p{So}\p{Sk}]";
+    // private const string regexTokenize = @"[\p{IsCJKUnifiedIdeographs}]|[a-z0-9]+";
+    // private const string regexWhitespace = @"\s+";
+    // private const string regexNotAWord = @"[^\w\s]";
 
     public IEnumerable<string> TokenizeAndPreprocess(string text)
     {
-        text = text.ToLower();
+        // text = text.ToLower();
 
-        // Check if text contains Chinese characters using the CJK Unified Ideographs block
-        if (Regex.IsMatch(text, regexMatchChineseCharacters))
+        // // Check if text contains Chinese characters using the CJK Unified Ideographs block
+        // if (Regex.IsMatch(text, regexMatchChineseCharacters))
+        // {
+        //     // Remove punctuation (excluding Chinese characters)
+        //     text = Regex.Replace(text, regexRemovePunctuation, string.Empty);
+        //     // Tokenize either by matching individual Chinese characters or contiguous word tokens (for Latin letters/digits)
+        //     var tokens = Regex.Matches(text, regexTokenize)
+        //                       .Cast<Match>()
+        //                       .Select(m => m.Value);
+        //     return tokens;
+        // }
+        // else
+        // {
+        //     text = Regex.Replace(text, regexNotAWord, string.Empty);
+        //     text = Regex.Replace(text, regexWhitespace, space).Trim();
+        //     return text.Split(charSpace);
+        // }
+
+        if (string.IsNullOrWhiteSpace(text)) return Array.Empty<string>();
+
+        text = text.ToLower();
+        text = Regex.Replace(text, regexRemovePunctuation, string.Empty);
+
+        string pattern = 
+            @"(\p{IsCJKUnifiedIdeographs})" +  // Match individual Chinese characters
+            @"|([\p{L}\p{M}\d]+)" +            // Match words (letters, numbers, including accents/diacritics)
+            @"|([\p{So}\p{Sk}])";              // Match emoji and symbols
+
+        MatchCollection matches = Regex.Matches(text, pattern);
+        List<string> result = new List<string>();
+
+        foreach (Match match in matches)
         {
-            // Remove punctuation (excluding Chinese characters)
-            text = Regex.Replace(text, regexRemovePunctuation, string.Empty);
-            // Tokenize either by matching individual Chinese characters or contiguous word tokens (for Latin letters/digits)
-            var tokens = Regex.Matches(text, regexTokenize)
-                              .Cast<Match>()
-                              .Select(m => m.Value);
-            return tokens;
+            // Split blocks of Chinese characters into individual characters
+            if (Regex.IsMatch(match.Value, @"^\p{IsCJKUnifiedIdeographs}+$"))
+            {
+                result.AddRange(match.Value.ToCharArray().Select(c => c.ToString()));
+            }
+            else
+            {
+                result.Add(match.Value);
+            }
         }
-        else
-        {
-            text = Regex.Replace(text, regexNotAWord, string.Empty);
-            text = Regex.Replace(text, regexWhitespace, space).Trim();
-            return text.Split(charSpace);
-        }
+
+        return result.ToArray();
     }
 
     public async Task<IEnumerable<string>> TokenizeAndPreprocessAsync(string text)

--- a/src/Build5Nines.SharpVector/VectorCompare/CosineSimilarityVectorComparerAsync.cs
+++ b/src/Build5Nines.SharpVector/VectorCompare/CosineSimilarityVectorComparerAsync.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace Build5Nines.SharpVector.VectorCompare;
 
@@ -56,22 +57,12 @@ public class CosineSimilarityVectorComparer : IVectorComparer
         return dotProduct / (magnitudeA * magnitudeB);
     }
 
-    public IEnumerable<VectorTextResultItem<TDocument, TMetadata>> Sort<TDocument, TMetadata>(IEnumerable<VectorTextResultItem<TDocument, TMetadata>> results)
+    public IEnumerable<IVectorTextResultItem<TId, TDocument, TMetadata>> Sort<TId, TDocument, TMetadata>(IEnumerable<IVectorTextResultItem<TId, TDocument, TMetadata>> results)
     {
         return results.OrderByDescending(s => s.VectorComparison);
     }
 
-    public IEnumerable<VectorTextResultItem<TMetadata>> Sort<TMetadata>(IEnumerable<VectorTextResultItem<TMetadata>> results)
-    {
-        return results.OrderByDescending(s => s.VectorComparison);
-    }
-
-    public async Task<IEnumerable<VectorTextResultItem<TDocument, TMetadata>>> SortAsync<TDocument, TMetadata>(IEnumerable<VectorTextResultItem<TDocument, TMetadata>> results)
-    {
-        return await Task.Run(() => Sort(results));
-    }
-
-    public async Task<IEnumerable<VectorTextResultItem<TMetadata>>> SortAsync<TMetadata>(IEnumerable<VectorTextResultItem<TMetadata>> results)
+    public async Task<IEnumerable<IVectorTextResultItem<TId, TDocument, TMetadata>>> SortAsync<TId, TDocument, TMetadata>(IEnumerable<IVectorTextResultItem<TId, TDocument, TMetadata>> results)
     {
         return await Task.Run(() => Sort(results));
     }

--- a/src/Build5Nines.SharpVector/VectorCompare/EuclideanDistanceVectorComparerAsync.cs
+++ b/src/Build5Nines.SharpVector/VectorCompare/EuclideanDistanceVectorComparerAsync.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace Build5Nines.SharpVector.VectorCompare;
 
 public class EuclideanDistanceVectorComparer : IVectorComparer
@@ -39,22 +41,12 @@ public class EuclideanDistanceVectorComparer : IVectorComparer
         return (float)Math.Sqrt(sumOfSquares);
     }
 
-    public IEnumerable<VectorTextResultItem<TMetadata>> Sort<TMetadata>(IEnumerable<VectorTextResultItem<TMetadata>> results)
+    public IEnumerable<IVectorTextResultItem<TId, TDocument, TMetadata>> Sort<TId, TDocument, TMetadata>(IEnumerable<IVectorTextResultItem<TId, TDocument, TMetadata>> results)
     {
         return results.OrderBy(s => s.VectorComparison);
     }
 
-    public async Task<IEnumerable<VectorTextResultItem<TMetadata>>> SortAsync<TMetadata>(IEnumerable<VectorTextResultItem<TMetadata>> results)
-    {
-        return await Task.Run(() => Sort(results));
-    }
-
-    public IEnumerable<VectorTextResultItem<TDocument, TMetadata>> Sort<TDocument, TMetadata>(IEnumerable<VectorTextResultItem<TDocument, TMetadata>> results)
-    {
-        return results.OrderBy(s => s.VectorComparison);
-    }
-
-    public async Task<IEnumerable<VectorTextResultItem<TDocument, TMetadata>>> SortAsync<TDocument, TMetadata>(IEnumerable<VectorTextResultItem<TDocument, TMetadata>> results)
+    public async Task<IEnumerable<IVectorTextResultItem<TId, TDocument, TMetadata>>> SortAsync<TId, TDocument, TMetadata>(IEnumerable<IVectorTextResultItem<TId, TDocument, TMetadata>> results)
     {
         return await Task.Run(() => Sort(results));
     }

--- a/src/Build5Nines.SharpVector/VectorCompare/IVectorComparer.cs
+++ b/src/Build5Nines.SharpVector/VectorCompare/IVectorComparer.cs
@@ -17,15 +17,7 @@ public interface IVectorComparer
     /// <typeparam name="TMetadata"></typeparam>
     /// <param name="results"></param>
     /// <returns></returns>
-    IEnumerable<VectorTextResultItem<TDocument, TMetadata>> Sort<TDocument, TMetadata>(IEnumerable<VectorTextResultItem<TDocument, TMetadata>> results);
-
-    /// <summary>
-    /// Sorts the results of a comparison
-    /// </summary>
-    /// <typeparam name="TMetadata"></typeparam>
-    /// <param name="results"></param>
-    /// <returns></returns>
-    IEnumerable<VectorTextResultItem<TMetadata>> Sort<TMetadata>(IEnumerable<VectorTextResultItem<TMetadata>> results);
+    IEnumerable<IVectorTextResultItem<TId, TDocument, TMetadata>> Sort<TId, TDocument, TMetadata>(IEnumerable<IVectorTextResultItem<TId, TDocument, TMetadata>> results);
 
     /// <summary>
     /// Determines if the comparison is within threshold threshold
@@ -50,14 +42,6 @@ public interface IVectorComparer
     /// <typeparam name="TMetadata"></typeparam>
     /// <param name="results"></param>
     /// <returns></returns>
-    Task<IEnumerable<VectorTextResultItem<TDocument, TMetadata>>> SortAsync<TDocument, TMetadata>(IEnumerable<VectorTextResultItem<TDocument, TMetadata>> results);
-
-    /// <summary>
-    /// Sorts the results of a comparison asynchronously    
-    /// </summary>
-    /// <typeparam name="TMetadata"></typeparam>
-    /// <param name="results"></param>
-    /// <returns></returns>
-    Task<IEnumerable<VectorTextResultItem<TMetadata>>> SortAsync<TMetadata>(IEnumerable<VectorTextResultItem<TMetadata>> results);
+    Task<IEnumerable<IVectorTextResultItem<TId, TDocument, TMetadata>>> SortAsync<TId, TDocument, TMetadata>(IEnumerable<IVectorTextResultItem<TId, TDocument, TMetadata>> results);
 }
 

--- a/src/Build5Nines.SharpVector/VectorStore/IVectorStore.cs
+++ b/src/Build5Nines.SharpVector/VectorStore/IVectorStore.cs
@@ -21,7 +21,7 @@ public interface IVectorStore<TId, TMetadata, TDocument>
     /// <param name="id"></param>
     /// <returns></returns>
     /// <exception cref="KeyNotFoundException"></exception>
-    VectorTextItem<TDocument, TMetadata> Get(TId id);
+    IVectorTextItem<TDocument, TMetadata> Get(TId id);
 
     /// <summary>
     /// Gets all the Ids for every text.
@@ -51,7 +51,7 @@ public interface IVectorStore<TId, TMetadata, TDocument>
     /// <param name="id"></param>
     /// <returns>The removed text item</returns>
     /// <exception cref="KeyNotFoundException"></exception>
-    VectorTextItem<TDocument, TMetadata> Delete(TId id);
+    IVectorTextItem<TDocument, TMetadata> Delete(TId id);
 
     /// <summary>
     /// Checks if the database contains a key

--- a/src/Build5Nines.SharpVector/VectorStore/MemoryDictionaryVectorStore.cs
+++ b/src/Build5Nines.SharpVector/VectorStore/MemoryDictionaryVectorStore.cs
@@ -62,7 +62,7 @@ public class MemoryDictionaryVectorStore<TId, TMetadata, TDocument> : IVectorSto
     /// <param name="id"></param>
     /// <returns></returns>
     /// <exception cref="KeyNotFoundException"></exception>
-    public VectorTextItem<TDocument, TMetadata> Get(TId id)
+    public IVectorTextItem<TDocument, TMetadata> Get(TId id)
     {
         if (_database.TryGetValue(id, out var entry))
         {
@@ -77,7 +77,7 @@ public class MemoryDictionaryVectorStore<TId, TMetadata, TDocument> : IVectorSto
     /// <param name="id"></param>
     /// <returns>The removed text item</returns>
     /// <exception cref="KeyNotFoundException"></exception>
-    public VectorTextItem<TDocument, TMetadata> Delete(TId id)
+    public IVectorTextItem<TDocument, TMetadata> Delete(TId id)
     {
         if (_database.ContainsKey(id))
         {

--- a/src/Build5Nines.SharpVector/VectorTextDatabaseItem.cs
+++ b/src/Build5Nines.SharpVector/VectorTextDatabaseItem.cs
@@ -1,0 +1,26 @@
+namespace Build5Nines.SharpVector;
+
+public interface IVectorTextDatabaseItem<TId, TDocument, TMetadata>
+{
+    TId Id { get; }
+    TDocument Text { get; }
+    TMetadata? Metadata { get; }
+    float[] Vector { get; }
+}
+
+public class VectorTextDatabaseItem<TId, TDocument, TMetadata>
+    : IVectorTextDatabaseItem<TId, TDocument, TMetadata>
+{
+    public VectorTextDatabaseItem(TId id, TDocument text, TMetadata? metadata, float[] vector)
+    {
+        Id = id;
+        Text = text;
+        Metadata = metadata;
+        Vector = vector;
+    }
+
+    public TId Id { get; private set; }
+    public TDocument Text { get; private set; }
+    public TMetadata? Metadata { get; private set; }
+    public float[] Vector { get; private set; }
+}

--- a/src/Build5Nines.SharpVector/VectorTextResult.cs
+++ b/src/Build5Nines.SharpVector/VectorTextResult.cs
@@ -3,10 +3,11 @@ namespace Build5Nines.SharpVector;
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 
-public interface IVectorTextResult<TDocument, TMetadata>
+public interface IVectorTextResult<TId, TDocument, TMetadata>
 {
-    IEnumerable<IVectorTextResultItem<TDocument, TMetadata>> Texts { get; }
+    IEnumerable<IVectorTextResultItem<TId, TDocument, TMetadata>> Texts { get; }
 
     /// <summary>
     /// Returns true if the search returned no results.
@@ -30,12 +31,13 @@ public interface IVectorTextResult<TDocument, TMetadata>
 }
 
 public interface IVectorTextResult<TMetadata>
- : IVectorTextResult<string, TMetadata>
+ : IVectorTextResult<int, string, TMetadata>
  { }
 
-public class VectorTextResult<TDocument, TMetadata> : IVectorTextResult<TDocument, TMetadata>
+public class VectorTextResult<TId, TDocument, TMetadata>
+    : IVectorTextResult<TId, TDocument, TMetadata>
 {
-    public VectorTextResult(int totalCount, int pageIndex, int totalPages, IEnumerable<IVectorTextResultItem<TDocument, TMetadata>> texts)
+    public VectorTextResult(int totalCount, int pageIndex, int totalPages, IEnumerable<IVectorTextResultItem<TId, TDocument, TMetadata>> texts)
     {
         Texts = texts;
         TotalCount = totalCount;
@@ -46,7 +48,7 @@ public class VectorTextResult<TDocument, TMetadata> : IVectorTextResult<TDocumen
     /// <summary>
     /// Returns true if the search returned no results.
     /// </summary>
-    public IEnumerable<IVectorTextResultItem<TDocument, TMetadata>> Texts { get; private set; }
+    public IEnumerable<IVectorTextResultItem<TId, TDocument, TMetadata>> Texts { get; private set; }
 
     public bool IsEmpty { get => Texts == null || !Texts.Any(); }
 
@@ -66,9 +68,10 @@ public class VectorTextResult<TDocument, TMetadata> : IVectorTextResult<TDocumen
     public int TotalPages { get; private set; }
 }
 
-public class VectorTextResult<TMetadata> : VectorTextResult<string, TMetadata>, IVectorTextResult<TMetadata>
+public class VectorTextResult<TMetadata>
+    : VectorTextResult<int, string, TMetadata>, IVectorTextResult<TMetadata>
 {
-    public VectorTextResult(int totalCount, int pageIndex, int totalPages, IEnumerable<IVectorTextResultItem<string, TMetadata>> texts)
+    public VectorTextResult(int totalCount, int pageIndex, int totalPages, IEnumerable<IVectorTextResultItem<int, string, TMetadata>> texts)
         : base(totalCount, pageIndex, totalPages, texts)
     { }
 }

--- a/src/Build5Nines.SharpVector/VectorTextResultItem.cs
+++ b/src/Build5Nines.SharpVector/VectorTextResultItem.cs
@@ -29,7 +29,7 @@ public class VectorTextResultItem<TId, TDocument, TMetadata>
 
     public VectorTextResultItem(TId id, IVectorTextItem<TDocument, TMetadata> item, float vectorComparison)
     {
-        _id = Id;
+        _id = id;
         _item = item;
         VectorComparison = vectorComparison;
     }

--- a/src/Build5Nines.SharpVector/VectorTextResultItem.cs
+++ b/src/Build5Nines.SharpVector/VectorTextResultItem.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Build5Nines.SharpVector.Id;
 
 namespace Build5Nines.SharpVector;
 
@@ -10,21 +11,32 @@ public interface IVectorTextResultItem<TDocument, TMetadata>
     float VectorComparison { get; }
 }
 
+public interface IVectorTextResultItem<TId, TDocument, TMetadata>
+    : IVectorTextResultItem<TDocument, TMetadata>
+{
+    TId Id { get; }
+}
+
 public interface IVectorTextResultItem<TMetadata>
- : IVectorTextResultItem<string, TMetadata>
+ : IVectorTextResultItem<string, TMetadata>, IVectorTextResultItem<int, string, TMetadata>
 { }
 
-public class VectorTextResultItem<TDocument, TMetadata> : IVectorTextResultItem<TDocument, TMetadata>
+public class VectorTextResultItem<TId, TDocument, TMetadata>
+    : IVectorTextResultItem<TDocument, TMetadata>, IVectorTextResultItem<TId, TDocument, TMetadata>
 {
     private IVectorTextItem<TDocument, TMetadata> _item;
-    public VectorTextResultItem(IVectorTextItem<TDocument, TMetadata> item, float vectorComparison)
+    private TId _id;
+
+    public VectorTextResultItem(TId id, IVectorTextItem<TDocument, TMetadata> item, float vectorComparison)
     {
+        _id = Id;
         _item = item;
         VectorComparison = vectorComparison;
     }
     
     public TDocument Text { get => _item.Text; }
     public TMetadata? Metadata { get => _item.Metadata; }
+    public TId Id { get => _id; }
 
     public ImmutableArray<float> Vectors { get => ImmutableArray.Create(_item.Vector); }
 
@@ -32,9 +44,10 @@ public class VectorTextResultItem<TDocument, TMetadata> : IVectorTextResultItem<
 }
 
 public class VectorTextResultItem<TMetadata>
- : VectorTextResultItem<string, TMetadata>, IVectorTextResultItem<TMetadata>
+ : VectorTextResultItem<int, string, TMetadata>, IVectorTextResultItem<TMetadata>
 {
-    public VectorTextResultItem(IVectorTextItem<string, TMetadata> item, float vectorComparison)
-        : base(item, vectorComparison)
+    public VectorTextResultItem(int id, IVectorTextItem<string, TMetadata> item, float vectorComparison)
+        : base(id, item, vectorComparison)
     { }
 }
+

--- a/src/ConsoleTest/Program.cs
+++ b/src/ConsoleTest/Program.cs
@@ -157,13 +157,11 @@ public static class Program
             Console.WriteLine(string.Empty);
 
             if (newPrompt != null) {
-                IVectorTextResult<string, string> result;
-                
                 timer.Restart();
 
                 var pageSize = 3;
                 // result = await vdb.Search(newPrompt,
-                result = await vdb.SearchAsync(newPrompt,
+                var result = await vdb.SearchAsync(newPrompt,
                     threshold: 0.001f, // 0.2f, // Cosine Similarity - Only return results with similarity greater than this threshold
                     // threshold: (float)1.4f, // Euclidean Distance - Only return results with distance less than this threshold
 

--- a/src/SharpVectorTest/Preprocessing/BasicTextPreprocessorTests.cs
+++ b/src/SharpVectorTest/Preprocessing/BasicTextPreprocessorTests.cs
@@ -18,8 +18,10 @@ public class VectorDatabaseTests
     public void TokenizeAndPreprocess_Null()
     {
         var preprocessor = new BasicTextPreprocessor();
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         var tokens = preprocessor.TokenizeAndPreprocess(null);
-        
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+
         Assert.AreEqual(0, tokens.Count());
     }
 

--- a/src/SharpVectorTest/Preprocessing/BasicTextPreprocessorTests.cs
+++ b/src/SharpVectorTest/Preprocessing/BasicTextPreprocessorTests.cs
@@ -42,6 +42,58 @@ public class VectorDatabaseTests
     }
 
     [TestMethod]
+    public void TokenizeAndPreprocess_Punctuation_01()
+    {
+        var preprocessor = new BasicTextPreprocessor();
+        var tokens = preprocessor.TokenizeAndPreprocess("Hello.!@#$%^&*()`~世-_=+ 界{}[]|:;\"',.<>/?!");
+        
+        var expectedTokens = new List<string> { "hello", "世", "界"};
+        for(var i = 0; i < expectedTokens.Count; i++)
+        {
+            Assert.AreEqual(expectedTokens[i], tokens.ElementAt(i), $"Index: {i} does not match");
+        }
+    }
+
+    [TestMethod]
+    public void TokenizeAndPreprocess_Punctuation_02()
+    {
+        var preprocessor = new BasicTextPreprocessor();
+        var tokens = preprocessor.TokenizeAndPreprocess("Hello.!@#$%^&*()`~-_=+{}[]|:;\"',.<>/?");
+        
+        var expectedTokens = new List<string> { "hello" };
+        for(var i = 0; i < expectedTokens.Count; i++)
+        {
+            Assert.AreEqual(expectedTokens[i], tokens.ElementAt(i), $"Index: {i} does not match");
+        }
+    }
+
+    [TestMethod]
+    public void TokenizeAndPreprocess_Punctuation_03()
+    {
+        var preprocessor = new BasicTextPreprocessor();
+        var tokens = preprocessor.TokenizeAndPreprocess("Hello.🔥!@#$%^&*()`~世-_=+ 界{}[]|:;\"',.<>/?");
+        
+        var expectedTokens = new List<string> { "hello", "🔥", "世", "界"};
+        for(var i = 0; i < expectedTokens.Count; i++)
+        {
+            Assert.AreEqual(expectedTokens[i], tokens.ElementAt(i), $"Index: {i} does not match");
+        }
+    }
+    
+    [TestMethod]
+    public void TokenizeAndPreprocess_Punctuation_04()
+    {
+        var preprocessor = new BasicTextPreprocessor();
+        var tokens = preprocessor.TokenizeAndPreprocess("Hello.!@#🔥$%^&*()`~-_=+{}[]|:;\"',.<>/?");
+        
+        var expectedTokens = new List<string> { "hello", "🔥" };
+        for(var i = 0; i < expectedTokens.Count; i++)
+        {
+            Assert.AreEqual(expectedTokens[i], tokens.ElementAt(i), $"Index: {i} does not match");
+        }
+    }
+
+    [TestMethod]
     public void TokenizeAndPreprocess_01()
     {
         var preprocessor = new BasicTextPreprocessor();
@@ -76,7 +128,7 @@ public class VectorDatabaseTests
         var expectedTokens = new List<string> { "hello", "world", "👑", "🔥", "how", "are", "you", "🔥" };
         for(var i = 0; i < expectedTokens.Count; i++)
         {
-            Assert.AreEqual(expectedTokens[i], tokens.ElementAt(i), $"Index: {i} does not match");
+            Assert.AreEqual(expectedTokens[i], tokens.ElementAt(i), $"Index: {i} does not match ::" + String.Join("-", tokens));
         }
     } 
 
@@ -89,7 +141,7 @@ public class VectorDatabaseTests
         var expectedTokens = new List<string> { "hello", "world", "👑", "🔥", "你", "好", "世", "界", "👑" };
         for(var i = 0; i < expectedTokens.Count; i++)
         {
-            Assert.AreEqual(expectedTokens[i], tokens.ElementAt(i), $"Index: {i} does not match");
+            Assert.AreEqual(expectedTokens[i], tokens.ElementAt(i), $"Index: {i} does not match ::" + String.Join("-", tokens));
         }
     }
 }

--- a/src/SharpVectorTest/Preprocessing/BasicTextPreprocessorTests.cs
+++ b/src/SharpVectorTest/Preprocessing/BasicTextPreprocessorTests.cs
@@ -1,0 +1,95 @@
+namespace SharpVectorTest.Preprocessing;
+
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Build5Nines.SharpVector;
+using Build5Nines.SharpVector.Embeddings;
+using Build5Nines.SharpVector.Id;
+using Build5Nines.SharpVector.Preprocessing;
+using Build5Nines.SharpVector.VectorCompare;
+using Build5Nines.SharpVector.Vectorization;
+using Build5Nines.SharpVector.VectorStore;
+using Build5Nines.SharpVector.Vocabulary;
+
+[TestClass]
+public class VectorDatabaseTests
+{
+    [TestMethod]
+    public void TokenizeAndPreprocess_Null()
+    {
+        var preprocessor = new BasicTextPreprocessor();
+        var tokens = preprocessor.TokenizeAndPreprocess(null);
+        
+        Assert.AreEqual(0, tokens.Count());
+    }
+
+    [TestMethod]
+    public void TokenizeAndPreprocess_Empty()
+    {
+        var preprocessor = new BasicTextPreprocessor();
+        var tokens = preprocessor.TokenizeAndPreprocess(string.Empty);
+        
+        Assert.AreEqual(0, tokens.Count());
+    }
+
+    [TestMethod]
+    public void TokenizeAndPreprocess_Whitespace()
+    {
+        var preprocessor = new BasicTextPreprocessor();
+        var tokens = preprocessor.TokenizeAndPreprocess(" ");
+        
+        Assert.AreEqual(0, tokens.Count());
+    }
+
+    [TestMethod]
+    public void TokenizeAndPreprocess_01()
+    {
+        var preprocessor = new BasicTextPreprocessor();
+        var tokens = preprocessor.TokenizeAndPreprocess("Hello, world! 你好，世界！");
+        
+        var expectedTokens = new List<string> { "hello", "world", "你", "好", "世", "界" };
+        for(var i = 0; i < expectedTokens.Count; i++)
+        {
+            Assert.AreEqual(expectedTokens[i], tokens.ElementAt(i), $"Index: {i} does not match");
+        }
+    }
+
+    [TestMethod]
+    public void TokenizeAndPreprocess_02()
+    {
+        var preprocessor = new BasicTextPreprocessor();
+        var tokens = preprocessor.TokenizeAndPreprocess("Hello, World! How are you?");
+        
+        var expectedTokens = new List<string> { "hello", "world", "how", "are", "you" };
+        for(var i = 0; i < expectedTokens.Count; i++)
+        {
+            Assert.AreEqual(expectedTokens[i], tokens.ElementAt(i), $"Index: {i} does not match");
+        }
+    }  
+
+    [TestMethod]
+    public void TokenizeAndPreprocess_03()
+    {
+        var preprocessor = new BasicTextPreprocessor();
+        var tokens = preprocessor.TokenizeAndPreprocess("Hello, World! 👑🔥 How are you? 🔥.");
+        
+        var expectedTokens = new List<string> { "hello", "world", "👑", "🔥", "how", "are", "you", "🔥" };
+        for(var i = 0; i < expectedTokens.Count; i++)
+        {
+            Assert.AreEqual(expectedTokens[i], tokens.ElementAt(i), $"Index: {i} does not match");
+        }
+    } 
+
+    [TestMethod]
+    public void TokenizeAndPreprocess_04()
+    {
+        var preprocessor = new BasicTextPreprocessor();
+        var tokens = preprocessor.TokenizeAndPreprocess("Hello, world! 👑🔥你好，世界！👑 ");
+        
+        var expectedTokens = new List<string> { "hello", "world", "👑", "🔥", "你", "好", "世", "界", "👑" };
+        for(var i = 0; i < expectedTokens.Count; i++)
+        {
+            Assert.AreEqual(expectedTokens[i], tokens.ElementAt(i), $"Index: {i} does not match");
+        }
+    }
+}

--- a/src/SharpVectorTest/VectorDatabaseTests.cs
+++ b/src/SharpVectorTest/VectorDatabaseTests.cs
@@ -80,6 +80,43 @@ public class VectorDatabaseTests
     }
 
     [TestMethod]
+    public void BasicMemoryVectorDatabase_05()
+    {
+        var vdb = new BasicMemoryVectorDatabase();
+        
+        // // Load Vector Database with some sample text
+        vdb.AddText("The 👑 King", "metadata1");
+        vdb.AddText("It's 🔥 Fire.", "metadata2");
+        vdb.AddText("No emoji", "metadata3");
+        
+        var results = vdb.Search("🔥", pageCount: 1);
+
+        Assert.AreEqual(1, results.Texts.Count());
+        Assert.AreEqual(1.0000001192092896, results.Texts.First().VectorComparison);
+        Assert.AreEqual("It's 🔥 Fire", results.Texts.First().Text);
+        Assert.AreEqual(2, results.Texts.First().Id);
+        Assert.AreEqual("metadata2", results.Texts.First().Metadata);
+    }
+
+    [TestMethod]
+    public void BasicMemoryVectorDatabase_06()
+    {
+        var vdb = new BasicMemoryVectorDatabase();
+        
+        // // Load Vector Database with some sample text
+        vdb.AddText("The 👑 King", "metadata1");
+        vdb.AddText("It's 🔥 Fire", "metadata2");
+        vdb.AddText("👑🔥 🏕️", "metadata3");
+        
+        var results = vdb.Search("🔥👑🏕️", pageCount: 1);
+
+        Assert.AreEqual(1, results.Texts.Count());
+        Assert.AreEqual("👑🔥 🏕️", results.Texts.First().Text);
+        Assert.AreEqual(3, results.Texts.First().Id);
+        Assert.AreEqual("metadata3", results.Texts.First().Metadata);
+    }
+
+    [TestMethod]
     public void BasicMemoryVectorDatabase_SaveLoadAsync_01()
     {
         var vdb = new BasicMemoryVectorDatabase();
@@ -575,16 +612,15 @@ public class VectorDatabaseTests
 
         var item = results.Texts.First();
 
-        Assert.AreEqual(id, item.Id, "ID should match the one returned by AddText.");
-
         vdb.UpdateText(item.Id, "TwoTwo");
         vdb.UpdateTextMetadata(item.Id, "222");
 
         results = await vdb.SearchAsync("Two");
 
-        Assert.AreEqual(3, results.Texts.Count());
-        Assert.AreEqual("TwoTwo", results.Texts.First().Text);
-        Assert.AreEqual("222", results.Texts.First().Metadata);
+        foreach(var i in results.Texts)
+        {
+            Assert.AreNotEqual("00000000-0000-0000-0000-000000000000", i.Id.ToString(), $"Search ID ({i.Text}) should not be empty.");
+        }
     }
 
     [TestMethod]

--- a/src/SharpVectorTest/VectorDatabaseTests.cs
+++ b/src/SharpVectorTest/VectorDatabaseTests.cs
@@ -1002,6 +1002,28 @@ public class VectorDatabaseTests
         var db = new EmbeddingGeneratorMemoryVectorDatabase();
         db.AddText("Test string", "metadata");
     }
+
+
+    [TestMethod]
+    public void BasicMemoryVectorDatabase_LoopThroughAllTexts_01()
+    {
+        var vdb = new BasicMemoryVectorDatabase();
+        
+        // // Load Vector Database with some sample text
+        vdb.AddText("The 👑 King", "metadata1");
+        vdb.AddText("It's 🔥 Fire.", "metadata2");
+        vdb.AddText("No emoji", "metadata3");
+
+        foreach(var item in vdb)
+        {
+            var id = item.Id;
+            var text = item.Text;
+            var metadata = item.Metadata;
+            var vector = item.Vector;
+            //Console.WriteLine($"ID: {item.Id}, Text: {item.Text}, Metadata: {item.Metadata}");
+            vdb.UpdateText(item.Id, item.Text + " - Updated");
+        }
+    }
 }
 
 public class MockMemoryVectorDatabase

--- a/src/SharpVectorTest/VectorDatabaseTests.cs
+++ b/src/SharpVectorTest/VectorDatabaseTests.cs
@@ -26,7 +26,7 @@ public class VectorDatabaseTests
 
         Assert.AreEqual(1, results.Texts.Count());
         Assert.IsTrue(results.Texts.First().Text.Contains("Lion King"));
-        Assert.AreEqual(0, results.Texts.First().Id);
+        Assert.AreEqual(1, results.Texts.First().Id);
         Assert.AreEqual("[some metadata here]", results.Texts.First().Metadata);
         Assert.AreEqual(0.3396831452846527, results.Texts.First().VectorComparison);
     }
@@ -506,18 +506,19 @@ public class VectorDatabaseTests
         var item = results.Texts.First();
 
         Assert.AreEqual(2, id);
+        Assert.AreEqual(id, item.Id, "ID should match the one returned by AddText.");
 
         vdb.UpdateTextMetadata(item.Id, "222");
 
         results = await vdb.SearchAsync("Two");
 
-        Assert.AreEqual(1, results.Texts.Count());
+        Assert.AreEqual(3, results.Texts.Count());
         Assert.AreEqual("Two", results.Texts.First().Text);
         Assert.AreEqual("222", results.Texts.First().Metadata);
 
         results = await vdb.SearchAsync("One");
 
-        Assert.AreEqual(1, results.Texts.Count());
+        Assert.AreEqual(3, results.Texts.Count());
         Assert.AreEqual("One", results.Texts.First().Text);
         Assert.AreEqual("1", results.Texts.First().Metadata);
     }
@@ -540,13 +541,13 @@ public class VectorDatabaseTests
 
         vdb.UpdateTextMetadata(item.Id, "222");
 
-        results = await vdb.SearchAsync("Two");
+        results = await vdb.SearchAsync("Two", pageCount: 1);
 
         Assert.AreEqual(1, results.Texts.Count());
         Assert.AreEqual("Two", results.Texts.First().Text);
         Assert.AreEqual("222", results.Texts.First().Metadata);
 
-        results = await vdb.SearchAsync("One");
+        results = await vdb.SearchAsync("One", pageCount: 1);
 
         Assert.AreEqual(1, results.Texts.Count());
         Assert.AreEqual("One", results.Texts.First().Text);
@@ -567,24 +568,23 @@ public class VectorDatabaseTests
 
         var results = await vdb.SearchAsync("Two");
 
+        foreach(var i in results.Texts)
+        {
+            Assert.AreNotEqual("00000000-0000-0000-0000-000000000000", i.Id.ToString(), $"Search ID ({i.Text}) should not be empty.");
+        }
+
         var item = results.Texts.First();
 
-        Assert.AreNotEqual("00000000-0000-0000-0000-000000000000", item.Id.ToString(), "Search ID should not be empty.");
+        Assert.AreEqual(id, item.Id, "ID should match the one returned by AddText.");
 
         vdb.UpdateText(item.Id, "TwoTwo");
         vdb.UpdateTextMetadata(item.Id, "222");
 
         results = await vdb.SearchAsync("Two");
 
-        Assert.AreEqual(1, results.Texts.Count());
-        Assert.AreEqual("Two", results.Texts.First().Text);
+        Assert.AreEqual(3, results.Texts.Count());
+        Assert.AreEqual("TwoTwo", results.Texts.First().Text);
         Assert.AreEqual("222", results.Texts.First().Metadata);
-
-        results = await vdb.SearchAsync("One");
-
-        Assert.AreEqual(1, results.Texts.Count());
-        Assert.AreEqual("One", results.Texts.First().Text);
-        Assert.AreEqual("1", results.Texts.First().Metadata);
     }
 
     [TestMethod]
@@ -610,13 +610,6 @@ public class VectorDatabaseTests
         Assert.AreEqual("狮子王是一部非常棒的电影！", results.Texts.First().Text);
         Assert.AreEqual("{ value: \"元数据初始值\" }", results.Texts.First().Metadata);
     }
-
-
-
-
-
-
-
 
     [TestMethod]
     public void EuclideanDistanceVectorComparerAsyncMemoryVectorDatabase_1()

--- a/src/SharpVectorTest/VectorDatabaseTests.cs
+++ b/src/SharpVectorTest/VectorDatabaseTests.cs
@@ -852,15 +852,16 @@ public class VectorDatabaseTests
     public void EmbeddingGeneratorMemoryVectorDatabase_001()
     {
         var db = new EmbeddingGeneratorMemoryVectorDatabase();
-        //db.AddText("Test string", "metadata");
+        db.AddText("Test string", "metadata");
     }
 }
 
 public class MockEmbeddingsGenerator : IEmbeddingsGenerator
 {
-    public Task<float[]> GenerateEmbeddingsAsync(string text)
+    public async Task<float[]> GenerateEmbeddingsAsync(string text)
     {
-        return new Task<float[]>(() => new float[] { 0.1f, 0.2f, 0.3f, 0.4f, 0.5f });
+        var val = new float[] { 0.1f, 0.2f, 0.3f, 0.4f, 0.5f };
+        return val;
     }
 }
 

--- a/src/SharpVectorTest/VectorDatabaseTests.cs
+++ b/src/SharpVectorTest/VectorDatabaseTests.cs
@@ -536,6 +536,39 @@ public class VectorDatabaseTests
 
         var item = results.Texts.First();
 
+        Assert.AreEqual(2, item.Id);
+
+        vdb.UpdateTextMetadata(item.Id, "222");
+
+        results = await vdb.SearchAsync("Two");
+
+        Assert.AreEqual(1, results.Texts.Count());
+        Assert.AreEqual("Two", results.Texts.First().Text);
+        Assert.AreEqual("222", results.Texts.First().Metadata);
+
+        results = await vdb.SearchAsync("One");
+
+        Assert.AreEqual(1, results.Texts.Count());
+        Assert.AreEqual("One", results.Texts.First().Text);
+        Assert.AreEqual("1", results.Texts.First().Metadata);
+    }
+
+    [TestMethod] 
+    public async Task SimpleTest_MemoryVectorDatabase_UpdateMetadata_02()
+    {
+        var vdb = new MockMemoryVectorDatabase();
+        
+        // // Load Vector Database with some sample text
+        vdb.AddText("One", "1");
+        vdb.AddText("Two", "2");
+        vdb.AddText("Three", "3");
+
+        var results = await vdb.SearchAsync("Two");
+
+        var item = results.Texts.First();
+
+        Assert.AreNotEqual("00000000-0000-0000-0000-000000000000", item.Id.ToString());
+
         vdb.UpdateTextMetadata(item.Id, "222");
 
         results = await vdb.SearchAsync("Two");
@@ -913,6 +946,23 @@ public class VectorDatabaseTests
         var db = new EmbeddingGeneratorMemoryVectorDatabase();
         db.AddText("Test string", "metadata");
     }
+}
+
+public class MockMemoryVectorDatabase
+     : MemoryVectorDatabaseBase<
+        Guid,
+        string,
+        MemoryDictionaryVectorStore<Guid, string>,
+        GuidIdGenerator,
+        CosineSimilarityVectorComparer
+        >
+{
+    public MockMemoryVectorDatabase()
+        : base(
+            new MockEmbeddingsGenerator(),
+            new MemoryDictionaryVectorStore<Guid, string>()
+            )
+    { }
 }
 
 public class MockEmbeddingsGenerator : IEmbeddingsGenerator

--- a/src/SharpVectorTest/VectorDatabaseTests.cs
+++ b/src/SharpVectorTest/VectorDatabaseTests.cs
@@ -92,8 +92,8 @@ public class VectorDatabaseTests
         var results = vdb.Search("🔥", pageCount: 1);
 
         Assert.AreEqual(1, results.Texts.Count());
-        Assert.AreEqual(1.0000001192092896, results.Texts.First().VectorComparison);
-        Assert.AreEqual("It's 🔥 Fire", results.Texts.First().Text);
+        Assert.AreEqual(0.5773503184318542, results.Texts.First().VectorComparison);
+        Assert.AreEqual("It's 🔥 Fire.", results.Texts.First().Text);
         Assert.AreEqual(2, results.Texts.First().Id);
         Assert.AreEqual("metadata2", results.Texts.First().Metadata);
     }

--- a/src/SharpVectorTest/VectorDatabaseTests.cs
+++ b/src/SharpVectorTest/VectorDatabaseTests.cs
@@ -3,6 +3,7 @@ namespace SharpVectorTest;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Build5Nines.SharpVector;
+using Build5Nines.SharpVector.Embeddings;
 using Build5Nines.SharpVector.Id;
 using Build5Nines.SharpVector.Preprocessing;
 using Build5Nines.SharpVector.VectorCompare;
@@ -846,8 +847,39 @@ public class VectorDatabaseTests
         results = vdb.Search("Lion King");
         Assert.AreEqual("{ value: \"New Value\" }", results.Texts.First().Metadata);
     }
+
+    [TestMethod]
+    public void EmbeddingGeneratorMemoryVectorDatabase_001()
+    {
+        var db = new EmbeddingGeneratorMemoryVectorDatabase();
+        //db.AddText("Test string", "metadata");
+    }
 }
 
+public class MockEmbeddingsGenerator : IEmbeddingsGenerator
+{
+    public Task<float[]> GenerateEmbeddingsAsync(string text)
+    {
+        return new Task<float[]>(() => new float[] { 0.1f, 0.2f, 0.3f, 0.4f, 0.5f });
+    }
+}
+
+public class EmbeddingGeneratorMemoryVectorDatabase
+     : MemoryVectorDatabaseBase<
+        int,
+        string,
+        MemoryDictionaryVectorStore<int, string>,
+        IntIdGenerator,
+        CosineSimilarityVectorComparer
+        >
+{
+    public EmbeddingGeneratorMemoryVectorDatabase()
+        : base(
+            new MockEmbeddingsGenerator(),
+            new MemoryDictionaryVectorStore<int, string>()
+            )
+    { }
+}
 
 public class EuclideanDistanceVectorComparerAsyncMemoryVectorDatabase<TMetadata>
      : MemoryVectorDatabaseBase<

--- a/src/SharpVectorTest/VectorStore/MemoryDictionaryVectorStoreTest.cs
+++ b/src/SharpVectorTest/VectorStore/MemoryDictionaryVectorStoreTest.cs
@@ -47,4 +47,34 @@ public class MemoryDictionaryVectorStoreTests
         Assert.AreEqual(11.0, vectorStoreTwo.Get(4).Vector[1]);
         Assert.AreEqual(12.0, vectorStoreTwo.Get(4).Vector[2]);
     }
+
+    [TestMethod]
+    public void MemoryVectorStore_001()
+    {
+        var vectorStore = new MemoryDictionaryVectorStore<int, string>();
+        vectorStore.Set(1, new VectorTextItem<string, string>("key1", "1", new float[] { 1.0F, 2.0F, 3.0F }));
+        vectorStore.Set(2, new VectorTextItem<string, string>("key2", "2", new float[] { 4.0F, 5.0F, 6.0F }));
+        vectorStore.Set(3, new VectorTextItem<string, string>("key3", "3", new float[] { 7.0F, 8.0F, 9.0F }));
+        vectorStore.Set(4, new VectorTextItem<string, string>("key4", "4", new float[] { 10.0F, 11.0F, 12.0F }));
+
+        var item = vectorStore.Get(2);
+        Assert.AreEqual("key2", item.Text);
+    }
+
+    [TestMethod]
+    public void MemoryVectorStore_002()
+    {
+        var vectorStore = new MemoryDictionaryVectorStore<int, string>();
+        vectorStore.Set(1, new VectorTextItem<string, string>("key1", "1", new float[] { 1.0F, 2.0F, 3.0F }));
+        vectorStore.Set(2, new VectorTextItem<string, string>("key2", "2", new float[] { 4.0F, 5.0F, 6.0F }));
+        vectorStore.Set(3, new VectorTextItem<string, string>("key3", "3", new float[] { 7.0F, 8.0F, 9.0F }));
+        vectorStore.Set(4, new VectorTextItem<string, string>("key4", "4", new float[] { 10.0F, 11.0F, 12.0F }));
+
+        foreach(var item in vectorStore)
+        {
+            Assert.IsNotNull(item.Value);
+            Assert.AreNotEqual(0, item.Key);
+        }
+    }
+
 }


### PR DESCRIPTION
Add:

- Added `VectorTextResultItem.Id` property so it's easy to get the database ID for search results if necessary.
- `IVectorDatabase` now inherits from `IEnumerable` so you can easily look through the texts documents that have been added to the database.

Fixed:

- Fixed text tokenization to correctly remove special characters
- Update `BasicTextPreprocessor` to support Emoji characters too
- Refactorings for more Clean Code

Breaking Changes:

- The `.Search` and `.SearchAsync` methods now return a `IVectorTextResultItem<TId, TDocument, TMetadata>` instead of `VectorTextResultItem<TDocument, TMetadata>`. If you're using things like the documentation shows, then you wont see any changes or have any issues with this update.
