### PR TITLE
Fix WAL file-handle leak in disk store recovery

### DIFF
--- a/src/Build5Nines.SharpVector/VectorStore/BasicDiskVectorStore.cs
+++ b/src/Build5Nines.SharpVector/VectorStore/BasicDiskVectorStore.cs
@@ -191,33 +191,40 @@ public class BasicDiskVectorStore<TId, TMetadata, TVocabularyStore, TVocabularyK
 
         // Replay WAL to recover any operations after the last checkpoint
         if (!File.Exists(_walPath)) return;
-        using var fs = new FileStream(_walPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        using var br = new BinaryReader(fs);
-        while (fs.Position < fs.Length)
-        {
-            bool isDelete = br.ReadBoolean();
-            var idJson = br.ReadString();
-            var id = JsonSerializer.Deserialize<TId>(idJson)!;
-            if (isDelete)
-            {
-                _index.TryRemove(id, out _);
-                _cache.TryRemove(id, out _);
-            }
-            else
-            {
-                var itemJson = br.ReadString();
-                var item = JsonSerializer.Deserialize<VectorTextItem<TVocabularyKey, TMetadata>>(itemJson)!;
 
-                // Append item to items file to bring storage up-to-date
-                using var ofs = new FileStream(_itemsPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
-                ofs.Seek(0, SeekOrigin.End);
-                var offset = ofs.Position;
-                WriteItem(ofs, item);
-                ofs.Flush(true);
-                _index[id] = offset;
-                _cache[id] = item;
+        // Scope the read handles so the file is closed before we overwrite it
+        // below; `using var` would otherwise hold the handle until the end of
+        // the method and File.WriteAllBytes would race against it on Windows.
+        using (var fs = new FileStream(_walPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+        using (var br = new BinaryReader(fs))
+        {
+            while (fs.Position < fs.Length)
+            {
+                bool isDelete = br.ReadBoolean();
+                var idJson = br.ReadString();
+                var id = JsonSerializer.Deserialize<TId>(idJson)!;
+                if (isDelete)
+                {
+                    _index.TryRemove(id, out _);
+                    _cache.TryRemove(id, out _);
+                }
+                else
+                {
+                    var itemJson = br.ReadString();
+                    var item = JsonSerializer.Deserialize<VectorTextItem<TVocabularyKey, TMetadata>>(itemJson)!;
+
+                    // Append item to items file to bring storage up-to-date
+                    using var ofs = new FileStream(_itemsPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+                    ofs.Seek(0, SeekOrigin.End);
+                    var offset = ofs.Position;
+                    WriteItem(ofs, item);
+                    ofs.Flush(true);
+                    _index[id] = offset;
+                    _cache[id] = item;
+                }
             }
         }
+
         // After successful replay, truncate WAL (commit)
         File.WriteAllBytes(_walPath, Array.Empty<byte>());
         PersistIndex();

--- a/src/Build5Nines.SharpVector/Vocabulary/BasicDiskVocabularyStore.cs
+++ b/src/Build5Nines.SharpVector/Vocabulary/BasicDiskVocabularyStore.cs
@@ -118,23 +118,30 @@ public class BasicDiskVocabularyStore<TKey> : IVocabularyStore<TKey, int>, IDisp
     {
         LoadIfExists();
         if (!File.Exists(_walPath)) return;
-        using var fs = new FileStream(_walPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        using var br = new BinaryReader(fs);
-        while (fs.Position < fs.Length)
+
+        // Scope the read handles so the file is closed before we overwrite it
+        // below; `using var` would otherwise hold the handle until the end of
+        // the method and File.WriteAllBytes would race against it on Windows.
+        using (var fs = new FileStream(_walPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+        using (var br = new BinaryReader(fs))
         {
-            int count = br.ReadInt32();
-            for (int i = 0; i < count; i++)
+            while (fs.Position < fs.Length)
             {
-                var tokenJson = br.ReadString();
-                var token = JsonSerializer.Deserialize<TKey>(tokenJson)!;
-                if (!_vocab.ContainsKey(token))
+                int count = br.ReadInt32();
+                for (int i = 0; i < count; i++)
                 {
-                    var idx = _vocab.Count;
-                    _vocab[token] = idx;
-                    _cache[token] = idx;
+                    var tokenJson = br.ReadString();
+                    var token = JsonSerializer.Deserialize<TKey>(tokenJson)!;
+                    if (!_vocab.ContainsKey(token))
+                    {
+                        var idx = _vocab.Count;
+                        _vocab[token] = idx;
+                        _cache[token] = idx;
+                    }
                 }
             }
         }
+
         File.WriteAllBytes(_walPath, Array.Empty<byte>());
         Persist();
     }


### PR DESCRIPTION
## Summary
- `RecoverFromWalOrIndex` in both `BasicDiskVocabularyStore` and `BasicDiskVectorStore` opened the WAL with `using var fs = …`, whose scope extends to method end. The subsequent `File.WriteAllBytes(_walPath, …)` then raced against the still-open handle and threw `IOException("The process cannot access the file '…wal' because it is being used by another process.")` on Windows.
- Fix: scope the `FileStream`/`BinaryReader` in an explicit `using (…)` block so they are disposed before the truncating write.
- The same bug pattern existed in both stores; only the vocabulary store version was hit first, masking the vector store one. Both are fixed in this PR.

## Test plan
- [x] `SharpVectorTest.DiskVectorDatabaseTests.AddAndGetText_PersistsToDisk` passes (previously failed with the IOException above)
- [x] `SharpVectorTest.DiskVectorDatabaseTests.Delete_RemovesFromIndexButKeepsFile` passes (previously failed with the same IOException)
- [x] Full test suite (`dotnet test src/SharpVectorTest`) — 66/66 green on this branch
- [x] No production behavior change beyond WAL recovery; the on-disk format is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)